### PR TITLE
Add FastMCP lifespan API example

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,10 @@ The client will connect to the server, list all available endpoints, and demonst
 ## Extending the Framework
 
 - **Add new resources/tools/prompts**: Define a function and register it with the server using the provided decorators or registration methods.
-- **Advanced examples**: See `lifespan_example.py` (server) for resource management, `oauth_example.py` (client) for authentication, and `streamable_http_example.py` (client) for HTTP transport.
+- **Advanced examples**:
+  - `mcp_server_bootstrap/lifespan_example.py` shows how to use FastMCP's lifespan API for setup/teardown of resources. Run it with `python mcp_server_bootstrap/lifespan_example.py`.
+  - `oauth_example.py` (client) for authentication.
+  - `streamable_http_example.py` (client) for HTTP transport.
 
 ## Documentation
 

--- a/mcp_server_bootstrap/README.md
+++ b/mcp_server_bootstrap/README.md
@@ -24,10 +24,14 @@ This project demonstrates how to create a simple MCP server that exposes multipl
    python server.py
    ```
    The server will start and expose all available endpoints for client interaction.
+3. Run the lifespan example to see resource setup/teardown:
+   ```sh
+   python lifespan_example.py
+   ```
 
 ## Files
 - `server.py`: Main entry point for the MCP server demo. Exposes echo, query_db, user, and project endpoints as resources, tools, and prompts.
-- `lifespan_example.py`: Advanced example showing how to use the MCP server lifespan API for resource management (e.g., database connections).
+- `lifespan_example.py`: Advanced example showing how to use the MCP server lifespan API for resource management (e.g., database connections). Run with `python lifespan_example.py`.
 - `requirements.txt`: Python dependencies for the server demo.
 
 ## Available Endpoints
@@ -48,7 +52,7 @@ The server exposes the following endpoints:
 ## Advanced Usage
 
 ### Lifespan API Example
-See `lifespan_example.py` for an example of managing resources (like database connections) during server startup and shutdown using the MCP lifespan API. This is useful for initializing and cleaning up resources that should persist for the server's lifetime.
+See `lifespan_example.py` for an example of managing resources (like database connections) during server startup and shutdown using the MCP lifespan API. Run it with `python lifespan_example.py` to observe initialization and cleanup of a resource that persists for the server's lifetime.
 
 ### Adding More Resources, Tools, and Prompts
 You can add more resources, tools, and prompts by defining new functions and registering them with the MCP server instance using the appropriate decorators or registration methods.

--- a/mcp_server_bootstrap/lifespan_example.py
+++ b/mcp_server_bootstrap/lifespan_example.py
@@ -1,0 +1,47 @@
+"""Lifespan API example for FastMCP.
+
+This script demonstrates using FastMCP's ``lifespan`` parameter to manage
+resources during server startup and shutdown. A fake database connection is
+created when the server starts and cleaned up when the server stops.
+
+Run with::
+
+    python lifespan_example.py
+"""
+
+from contextlib import asynccontextmanager
+from typing import AsyncIterator, Dict, Any
+
+from mcp.server.fastmcp import Context, FastMCP
+
+
+@asynccontextmanager
+async def lifespan(app: FastMCP) -> AsyncIterator[Dict[str, Any]]:
+    """Manage the lifespan of a fake database connection."""
+    # Setup phase - create resource
+    db = {"connected": True, "items": []}
+    print("Lifespan startup: opened fake database connection")
+    try:
+        yield db  # Make the resource available to endpoints via lifespan context
+    finally:
+        # Teardown phase - clean up resource
+        db["connected"] = False
+        print("Lifespan shutdown: closed fake database connection")
+
+
+mcp = FastMCP(
+    "Lifespan Example Server",
+    lifespan=lifespan,
+)
+
+
+@mcp.tool()
+def add_item(item: str, ctx: Context) -> Dict[str, Any]:
+    """Add an item to the fake database and return all items."""
+    db = ctx.request_context.lifespan_context
+    db["items"].append(item)
+    return {"items": list(db["items"])}
+
+
+if __name__ == "__main__":
+    mcp.run()

--- a/mcp_server_bootstrap/lifespan_example.py
+++ b/mcp_server_bootstrap/lifespan_example.py
@@ -40,7 +40,7 @@ def add_item(item: str, ctx: Context) -> Dict[str, Any]:
     """Add an item to the fake database and return all items."""
     db = ctx.request_context.lifespan_context
     db["items"].append(item)
-    return {"items": list(db["items"])}
+    return {"items": db["items"]}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- illustrate FastMCP lifespan usage with a fake DB resource in `lifespan_example.py`
- mention lifespan example and execution instructions in README files

## Testing
- `python lifespan_example.py` (shows startup and cleanup messages)
- `python -m py_compile mcp_server_bootstrap/lifespan_example.py`


------
https://chatgpt.com/codex/tasks/task_e_68978f3e0ab0833295e812b0542464e4