### PR TITLE
Add tests and improve bootstrap robustness

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,18 @@ This repo is both a **template** and a **living context prompt** for AI agents a
 
 The client will connect to the server, list all available endpoints, and demonstrate calling each one.
 
+### Testing
+
+Automated tests ensure the bootstrap client and server continue to work as the
+project evolves.  After installing the dependencies, run:
+
+```sh
+pip install -r requirements.txt
+pytest --cov=mcp_server_bootstrap --cov=mcp_client_bootstrap
+```
+
+This will execute the unit tests and report code coverage for both packages.
+
 ## Extending the Framework
 
 - **Add new resources/tools/prompts**: Define a function and register it with the server using the provided decorators or registration methods.
@@ -91,4 +103,5 @@ This project is licensed under the MIT License. See [LICENSE](LICENSE) for detai
 ---
 
 **AI/Developer Note:**  
-This README is intended as a context prompt for both human and AI agents. When starting a new MCP-based app, use this structure and philosophy as your foundation. Extend, remix, and build upon it to create powerful, interoperable, and context-aware applications. 
+This README is intended as a context prompt for both human and AI agents. When starting a new MCP-based app, use this structure and philosophy as your foundation. Extend, remix, and build upon it to create powerful, interoperable, and context-aware applications.
+

--- a/mcp_client_bootstrap/README.md
+++ b/mcp_client_bootstrap/README.md
@@ -58,4 +58,5 @@ See `oauth_example.py` for an example of using OAuth authentication with the MCP
 - [Model Context Protocol Specification](https://modelcontextprotocol.io)
 
 ## Contributing
-Contributions are welcome! Please see the MCP Python SDK repository for guidelines. 
+Contributions are welcome! Please see the MCP Python SDK repository for guidelines.
+

--- a/mcp_client_bootstrap/client.py
+++ b/mcp_client_bootstrap/client.py
@@ -1,27 +1,29 @@
+"""MCP Client Bootstrap Demo.
+
+This script demonstrates how to interact with the demo MCP server using the
+Model Context Protocol Python SDK.  It lists every available prompt, resource
+and tool exposed by the server and exercises them one by one.
+
+The module is intentionally lightweight so it can be imported without having
+the ``mcp`` package installed.  The heavy imports occur inside :func:`main` so
+that documentation tools or static analysers do not need the dependency.
 """
-MCP Client Bootstrap Demo
 
-This is a minimal working demo of an MCP client using the Model Context Protocol Python SDK.
+from __future__ import annotations
 
-Demonstrates:
-- Listing and calling all available prompts, resources, and tools from the server.
-- Interacting with echo, query_db, user, and project endpoints.
-
-See also:
-- Advanced examples: streamable_http_example.py, oauth_example.py
-- MCP Python SDK documentation: https://github.com/modelcontextprotocol/python-sdk?tab=readme-ov-file#adding-mcp-to-your-python-project
-"""
 import asyncio
-from mcp import ClientSession, StdioServerParameters
-from mcp.client.stdio import stdio_client
+from pathlib import Path
+
 
 def print_header(title: str) -> None:
     """Print a formatted section header."""
+
     print(f"\n=== {title} ===")
 
 
 def _print_resource_result(name: str, result) -> None:
     """Print the contents of a resource result."""
+
     if result.contents:
         for content in result.contents:
             if hasattr(content, "text"):
@@ -31,15 +33,25 @@ def _print_resource_result(name: str, result) -> None:
     else:
         print(f"{name} resource result: <no content>")
 
+
 async def main() -> None:
-    """
-    Connect to a local MCP server using stdio, list and call all available prompts, resources, and tools.
-    Demonstrates echo, query_db, user, and project endpoints.
-    """
-    # Assumes a local server is running as 'python ../mcp_server_bootstrap/server.py'
+    """Connect to the demo MCP server and exercise all endpoints."""
+
+    # Import MCP components only when ``main`` runs.  This allows the module to
+    # be imported without the dependency being present, which is handy for
+    # documentation generation or static analysis.
+    from mcp import ClientSession, StdioServerParameters
+    from mcp.client.stdio import stdio_client
+
+    server_script = (
+        Path(__file__).resolve().parent.parent
+        / "mcp_server_bootstrap"
+        / "server.py"
+    )
+
     server_params = StdioServerParameters(
         command="python",
-        args=["../mcp_server_bootstrap/server.py"],
+        args=[str(server_script)],
     )
 
     async with stdio_client(server_params) as (read, write):
@@ -50,18 +62,20 @@ async def main() -> None:
             prompts = await session.list_prompts()
             print_header("Prompts")
             print(prompts)
-            # Call all prompts
             for prompt in prompts.prompts:
-                result = await session.get_prompt(prompt.name, {"message": f"Test message for {prompt.name}"})
-                # Print all messages in the prompt result
+                result = await session.get_prompt(
+                    prompt.name, {"message": f"Test message for {prompt.name}"}
+                )
                 print(f"Prompt '{prompt.name}' result:")
                 for msg in result.messages:
                     content = msg.content
-                    if hasattr(content, "type") and content.type == "text":
+                    if getattr(content, "type", None) == "text":
                         print(f"  [{msg.role}] {content.text}")
-                    elif hasattr(content, "type") and content.type == "image":
-                        print(f"  [{msg.role}] <image content, {getattr(content, 'mimeType', 'unknown type')}>")
-                    elif hasattr(content, "type") and content.type == "resource":
+                    elif getattr(content, "type", None) == "image":
+                        print(
+                            f"  [{msg.role}] <image content, {getattr(content, 'mimeType', 'unknown type')}>"
+                        )
+                    elif getattr(content, "type", None) == "resource":
                         print(f"  [{msg.role}] <embedded resource>")
                     else:
                         print(f"  [{msg.role}] <unknown content type>")
@@ -69,28 +83,31 @@ async def main() -> None:
             resources = await session.list_resources()
             print_header("Resources")
             print(resources)
-            # Call echo resource
             echo_res = await session.read_resource("echo://hello-client")
             _print_resource_result("Echo", echo_res)
-            # Call user resource
             user_res = await session.read_resource("user://1")
             _print_resource_result("User", user_res)
-            # Call project resource
             project_res = await session.read_resource("project://101")
             _print_resource_result("Project", project_res)
 
             tools = await session.list_tools()
             print_header("Tools")
             print(tools.tools)
-            # Call all tools
             for tool in tools.tools:
                 if tool.name == "echo_tool":
-                    result = await session.call_tool(tool.name, {"message": "hello tools"})
+                    result = await session.call_tool(
+                        tool.name, {"message": "hello tools"}
+                    )
                 elif tool.name == "query_db":
-                    result = await session.call_tool(tool.name, {"arguments": {"table": "users", "filter": {"name": "Alice"}}})
+                    result = await session.call_tool(
+                        tool.name,
+                        {"arguments": {"table": "users", "filter": {"name": "Alice"}}},
+                    )
                 else:
                     result = await session.call_tool(tool.name, {})
                 print(f"Tool '{tool.name}' result:", result)
 
+
 if __name__ == "__main__":
-    asyncio.run(main()) 
+    asyncio.run(main())
+

--- a/mcp_client_bootstrap/requirements.txt
+++ b/mcp_client_bootstrap/requirements.txt
@@ -1,1 +1,1 @@
-mcp[cli] 
+mcp[cli]

--- a/mcp_server_bootstrap/README.md
+++ b/mcp_server_bootstrap/README.md
@@ -62,4 +62,5 @@ You can add more resources, tools, and prompts by defining new functions and reg
 - [Model Context Protocol Specification](https://modelcontextprotocol.io)
 
 ## Contributing
-Contributions are welcome! Please see the MCP Python SDK repository for guidelines. 
+Contributions are welcome! Please see the MCP Python SDK repository for guidelines.
+

--- a/mcp_server_bootstrap/requirements.txt
+++ b/mcp_server_bootstrap/requirements.txt
@@ -1,1 +1,1 @@
-mcp[cli] 
+mcp[cli]

--- a/mcp_server_bootstrap/server.py
+++ b/mcp_server_bootstrap/server.py
@@ -18,8 +18,7 @@ from mcp.server.fastmcp import FastMCP
 
 mcp = FastMCP(
     "Demo Server",
-    description="A minimal MCP server demo for Cursor integration.",
-    version="0.1.0"
+    instructions="A minimal MCP server demo for MCP integration."
 )
 
 def echo_resource(message: str) -> str:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+mcp[cli]
+pytest
+pytest-cov
+

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,0 +1,56 @@
+"""Tests for the MCP bootstrap demo."""
+
+import asyncio
+
+import pytest
+
+from mcp_server_bootstrap import server
+from mcp_client_bootstrap import client
+
+
+def test_echo_resource():
+    assert server.echo_resource("hi") == "Resource echo: hi"
+
+
+def test_echo_tool():
+    assert server.echo_tool("hello") == "Tool echo: hello"
+
+
+def test_echo_prompt():
+    assert server.echo_prompt("foo") == "Please process this message: foo"
+
+
+def test_query_db_happy_path():
+    res = server.query_db({"table": "users", "filter": {"name": "Alice"}})
+    assert res == {
+        "results": [
+            {"id": 1, "name": "Alice", "email": "alice@example.com"}
+        ]
+    }
+
+
+def test_query_db_error_cases():
+    assert server.query_db("bad") == {"error": "Arguments must be a dictionary."}
+    assert server.query_db({"filter": {}})["error"].startswith("Missing required")
+    assert server.query_db({"table": "users", "filter": "no"}) == {
+        "error": "'filter' must be a dictionary if provided."
+    }
+    assert server.query_db({"table": "missing"}) == {
+        "error": "Table missing not found."
+    }
+
+
+def test_user_resource():
+    assert server.user_resource(1)["name"] == "Alice"
+    assert server.user_resource(999)["error"] == "User not found."
+
+
+def test_project_resource():
+    assert server.project_resource(101)["title"] == "Demo Project"
+    assert server.project_resource(999)["error"] == "Project not found."
+
+
+def test_client_main_runs():
+    pytest.importorskip("mcp")
+    asyncio.run(client.main())
+


### PR DESCRIPTION
## Summary
- resolve server path relative to the client module and import MCP lazily
- align FastMCP setup with available SDK arguments
- add pytest-based test suite and root requirements for easy setup
- document how to run tests and measure coverage

## Testing
- `python -m pytest` *(passes: 8 passed)*
- `python -m pytest --cov=mcp_server_bootstrap --cov=mcp_client_bootstrap` *(fails: unrecognized arguments: --cov ...)*

------
https://chatgpt.com/codex/tasks/task_e_68979544746c833282db48378150a6c9